### PR TITLE
Add feature to show dialog only if pass both significant event counter a...

### DIFF
--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -115,6 +115,18 @@ public class AppRate {
         return isMeetsConditions;
     }
 
+    public static boolean passSignificantEventAndConditions(Activity activity) {
+        boolean isMeetsConditions = singleton.isDebug || (singleton.isOverEventPass() && singleton.shouldShowRateDialog());
+        if (isMeetsConditions) {
+            singleton.showRateDialog(activity);
+        } else {
+            Context context = activity.getApplicationContext();
+            int eventTimes = PreferenceHelper.getEventTimes(context);
+            PreferenceHelper.setEventTimes(context, ++eventTimes);
+        }
+        return isMeetsConditions;
+    }
+
     public void showRateDialog(Activity activity) {
         if(!activity.isFinishing()) {
             DialogManager.create(activity, isShowNeutralButton, listener, view).show();


### PR DESCRIPTION
...nd conditions.

This allows the app to specify that it wants to check both the significant event counter
and any conditions set before showing the rate dialog.