### PR TITLE
Setting Google Play package name for intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Please try to move the [sample module](https://github.com/hotchemi/Android-Rate/
 
 ## How to use
 
+Javadoc is [here](http://www.javadoc.io/doc/com.github.hotchemi/android-rate/).
+
 ### Configuration
 
 Android-Rate provides methods to configure its behavior.

--- a/library/src/main/java/hotchemi/android/rate/UriHelper.java
+++ b/library/src/main/java/hotchemi/android/rate/UriHelper.java
@@ -19,10 +19,8 @@ final class UriHelper {
     }
 
     static boolean isPackageExists(Context context, String targetPackage) {
-        List<ApplicationInfo> packages;
-        PackageManager pm;
-        pm = context.getPackageManager();
-        packages = pm.getInstalledApplications(0);
+        PackageManager pm = context.getPackageManager();
+        List<ApplicationInfo> packages = pm.getInstalledApplications(0);
         for (ApplicationInfo packageInfo : packages) {
             if (packageInfo.packageName.equals(targetPackage)) return true;
         }


### PR DESCRIPTION
I've added setting Google Play package name for rate intent (if available). This will allow to avoid the 'Complete Action by using (Play, Chrome, Web Browser)' dialog