### PR TITLE
isShowTitle setting

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '19.1.0'
+    compileSdkVersion 21
+    buildToolsVersion '21.1.2'
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 19
+        targetSdkVersion 21
     }
 }
 

--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -18,6 +18,8 @@ public class AppRate {
 
     private int eventsTimes = -1;
 
+    private boolean isShowTitle = true;
+
     private boolean isShowNeutralButton = true;
 
     private boolean isDebug = false;
@@ -65,6 +67,11 @@ public class AppRate {
 
     public AppRate setEventsTimes(int eventsTimes) {
         this.eventsTimes = eventsTimes;
+        return this;
+    }
+
+    public AppRate setShowTitle(boolean isShowTitle) {
+        this.isShowTitle = isShowTitle;
         return this;
     }
 
@@ -129,7 +136,7 @@ public class AppRate {
 
     public void showRateDialog(Activity activity) {
         if(!activity.isFinishing()) {
-            DialogManager.create(activity, isShowNeutralButton, listener, view).show();
+            DialogManager.create(activity, isShowNeutralButton, isShowTitle, listener, view).show();
         }
     }
 

--- a/library/src/main/java/hotchemi/android/rate/DialogManager.java
+++ b/library/src/main/java/hotchemi/android/rate/DialogManager.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.view.View;
+import android.view.Window;
 
 final class DialogManager {
     private static final String GOOGLE_PLAY_PACKAGE_NAME = "com.android.vending";
@@ -14,9 +15,9 @@ final class DialogManager {
     }
 
     static Dialog create(final Context context, final boolean isShowNeutralButton,
-                         final OnClickButtonListener listener, final View view) {
+                         final boolean isShowTitle, final OnClickButtonListener listener,
+                         final View view) {
         final AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.rate_dialog_title);
         builder.setMessage(R.string.rate_dialog_message);
         if (view != null) builder.setView(view);
         builder.setPositiveButton(R.string.rate_dialog_ok, new DialogInterface.OnClickListener() {
@@ -48,7 +49,13 @@ final class DialogManager {
                 if (listener != null) listener.onClickButton(which);
             }
         });
-        return builder.create();
+        final AlertDialog dialog = builder.create();
+        if (!isShowTitle) {
+            dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        } else {
+            dialog.setTitle(R.string.rate_dialog_title);
+        }
+        return dialog;
     }
 
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion '19.1.0'
+    buildToolsVersion '21.1.2'
 
     defaultConfig {
         minSdkVersion 7
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:21.0.2'
+    compile 'com.android.support:appcompat-v7:21.0.3'
     compile fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     compile project(':library')
 }

--- a/sample/src/main/java/hotchemi/android/rate/sample/MainActivity.java
+++ b/sample/src/main/java/hotchemi/android/rate/sample/MainActivity.java
@@ -16,10 +16,11 @@ public class MainActivity extends ActionBarActivity {
 
         AppRate.with(this)
                 .setInstallDays(0) // default 10, 0 means install day.
-                .setLaunchTimes(3) // default 10 times.
+                .setLaunchTimes(1) // default 10 times.
                 .setRemindInterval(2) // default 1 day.
                 .setShowNeutralButton(true) // default true.
                 .setDebug(false) // default false.
+                .setShowTitle(false) // default true
                 .setOnClickButtonListener(new OnClickButtonListener() { // callback listener.
                     @Override
                     public void onClickButton(int which) {


### PR DESCRIPTION
Most of the time the title in `AlertDialog` looks too general and it would be great to hide it completely in such cases.
I've added the setting which allows to hide/show dialog title accordingly to their needs.