### PR TITLE
add reset data feature

### DIFF
--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -83,6 +83,12 @@ public class AppRate {
         return this;
     }
 
+    public AppRate clearSettingsParam() {
+        PreferenceHelper.setAgreeShowDialog(context, true);
+        PreferenceHelper.clearSharedPreferences(context);
+        return this;
+    }
+
     public AppRate setAgreeShowDialog(boolean clear) {
         PreferenceHelper.setAgreeShowDialog(context, clear);
         return this;


### PR DESCRIPTION
In case an application is upgraded, we might want to reset app rate
dialog data. So the dialog will be showed after some days or several
time used.