### PR TITLE
Add support for marshmallow

### DIFF
--- a/library/src/main/java/hotchemi/android/rate/Utils.java
+++ b/library/src/main/java/hotchemi/android/rate/Utils.java
@@ -14,12 +14,12 @@ final class Utils {
         return Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB;
     }
 
-    static boolean isLollipop() {
-        return Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP || Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP_MR1;
+    static boolean greaterThanKitKat() {
+        return Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
     }
 
     static int getDialogTheme() {
-        return isLollipop() ? R.style.CustomLollipopDialogStyle : 0;
+        return greaterThanKitKat() ? R.style.CustomLollipopDialogStyle : 0;
     }
 
     @SuppressLint("NewApi")


### PR DESCRIPTION
What I would like to have is to be able to add your own theme to the DialogOptions. Here I took a little  shortcut for now since it wasn't working for Android 6.x Marshmallow.