### PR TITLE
Added support for custom String content

### DIFF
--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -114,8 +114,18 @@ public class AppRate {
         return this;
     }
 
+    public AppRate setTitle(String title){
+        options.setTitleText(title);
+        return  this;
+    }
+
     public AppRate setMessage(int resourceId) {
         options.setMessageResId(resourceId);
+        return this;
+    }
+
+    public AppRate setMessage(String message) {
+        options.setMessageText(message);
         return this;
     }
 
@@ -124,13 +134,28 @@ public class AppRate {
         return this;
     }
 
+    public AppRate setTextRateNow(String rateNow) {
+        options.setPositiveText(rateNow);
+        return this;
+    }
+
     public AppRate setTextLater(int resourceId) {
         options.setTextNeutralResId(resourceId);
         return this;
     }
 
+    public AppRate setTextLater(String textLater) {
+        options.setNeutralText(textLater);
+        return this;
+    }
+
     public AppRate setTextNever(int resourceId) {
         options.setTextNegativeResId(resourceId);
+        return this;
+    }
+
+    public AppRate setTextNever(String textNever) {
+        options.setNegativeText(textNever);
         return this;
     }
 

--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -48,6 +48,36 @@ public class AppRate {
         return singleton;
     }
 
+    public static boolean showRateDialogIfMeetsConditions(Activity activity) {
+        boolean isMeetsConditions = singleton.isDebug || singleton.shouldShowRateDialog();
+        if (isMeetsConditions) {
+            singleton.showRateDialog(activity);
+        }
+        return isMeetsConditions;
+    }
+
+    public static boolean passSignificantEvent(Activity activity) {
+        return passSignificantEvent(activity, true);
+    }
+
+    public static boolean passSignificantEventAndConditions(Activity activity) {
+        return passSignificantEvent(activity, singleton.shouldShowRateDialog());
+    }
+
+    private static boolean passSignificantEvent(Activity activity, boolean shouldShow) {
+        int eventTimes = getEventTimes(activity);
+        PreferenceHelper.setEventTimes(activity, ++eventTimes);
+        boolean isMeetsConditions = singleton.isDebug || (singleton.isOverEventPass() && shouldShow);
+        if (isMeetsConditions) {
+            singleton.showRateDialog(activity);
+        }
+        return isMeetsConditions;
+    }
+
+    private static boolean isOverDate(long targetDate, int threshold) {
+        return new Date().getTime() - targetDate >= threshold * 24 * 60 * 60 * 1000;
+    }
+
     public AppRate setLaunchTimes(int launchTimes) {
         this.launchTimes = launchTimes;
         return this;
@@ -94,11 +124,6 @@ public class AppRate {
         return this;
     }
 
-    public AppRate setDebug(boolean isDebug) {
-        this.isDebug = isDebug;
-        return this;
-    }
-
     public AppRate setView(View view) {
         options.setView(view);
         return this;
@@ -114,9 +139,9 @@ public class AppRate {
         return this;
     }
 
-    public AppRate setTitle(String title){
+    public AppRate setTitle(String title) {
         options.setTitleText(title);
-        return  this;
+        return this;
     }
 
     public AppRate setMessage(int resourceId) {
@@ -134,8 +159,8 @@ public class AppRate {
         return this;
     }
 
-    public AppRate setTextRateNow(String rateNow) {
-        options.setPositiveText(rateNow);
+    public AppRate setTextRateNow(String positiveText) {
+        options.setPositiveText(positiveText);
         return this;
     }
 
@@ -144,8 +169,8 @@ public class AppRate {
         return this;
     }
 
-    public AppRate setTextLater(String textLater) {
-        options.setNeutralText(textLater);
+    public AppRate setTextLater(String neutralText) {
+        options.setNeutralText(neutralText);
         return this;
     }
 
@@ -154,8 +179,8 @@ public class AppRate {
         return this;
     }
 
-    public AppRate setTextNever(String textNever) {
-        options.setNegativeText(textNever);
+    public AppRate setTextNever(String negativeText) {
+        options.setNegativeText(negativeText);
         return this;
     }
 
@@ -169,32 +194,6 @@ public class AppRate {
             setInstallDate(context);
         }
         PreferenceHelper.setLaunchTimes(context, getLaunchTimes(context) + 1);
-    }
-
-    public static boolean showRateDialogIfMeetsConditions(Activity activity) {
-        boolean isMeetsConditions = singleton.isDebug || singleton.shouldShowRateDialog();
-        if (isMeetsConditions) {
-            singleton.showRateDialog(activity);
-        }
-        return isMeetsConditions;
-    }
-
-    public static boolean passSignificantEvent(Activity activity) {
-        return passSignificantEvent(activity, true);
-    }
-
-    public static boolean passSignificantEventAndConditions(Activity activity) {
-        return passSignificantEvent(activity, singleton.shouldShowRateDialog());
-    }
-
-    private static boolean passSignificantEvent(Activity activity, boolean shouldShow) {
-        int eventTimes = getEventTimes(activity);
-        PreferenceHelper.setEventTimes(activity, ++eventTimes);
-        boolean isMeetsConditions = singleton.isDebug || (singleton.isOverEventPass() && shouldShow);
-        if (isMeetsConditions) {
-            singleton.showRateDialog(activity);
-        }
-        return isMeetsConditions;
     }
 
     public void showRateDialog(Activity activity) {
@@ -226,12 +225,13 @@ public class AppRate {
         return isOverDate(getRemindInterval(context), remindInterval);
     }
 
-    private static boolean isOverDate(long targetDate, int threshold) {
-        return new Date().getTime() - targetDate >= threshold * 24 * 60 * 60 * 1000;
-    }
-
     public boolean isDebug() {
         return isDebug;
+    }
+
+    public AppRate setDebug(boolean isDebug) {
+        this.isDebug = isDebug;
+        return this;
     }
 
 }

--- a/library/src/main/java/hotchemi/android/rate/DialogManager.java
+++ b/library/src/main/java/hotchemi/android/rate/DialogManager.java
@@ -18,20 +18,9 @@ final class DialogManager {
 
     static Dialog create(final Context context, DialogOptions options) {
         AlertDialog.Builder builder = getDialogBuilder(context);
-        if(options.getMessageText() == null) {
-            builder.setMessage(options.getMessageResId());
-        }
-        else{
-            builder.setMessage(options.getMessageText());
-        }
+        builder.setMessage(options.getMessageText(context));
 
-        if (options.shouldShowTitle()){
-            if(options.getTitleText() == null) {
-                builder.setTitle(options.getTitleResId());
-            } else{
-                builder.setTitle(options.getTitleText());
-            }
-        }
+        if (options.shouldShowTitle()) builder.setTitle(options.getTitleText(context));
 
         builder.setCancelable(options.getCancelable());
 
@@ -40,53 +29,32 @@ final class DialogManager {
 
         final OnClickButtonListener listener = options.getListener();
 
-        DialogInterface.OnClickListener positiveClickListener = new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(options.getPositiveText(context), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 context.startActivity(createIntentForGooglePlay(context));
                 setAgreeShowDialog(context, false);
                 if (listener != null) listener.onClickButton(which);
             }
-        };
+        });
 
-        DialogInterface.OnClickListener neutralClickListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                setRemindInterval(context);
-                if (listener != null) listener.onClickButton(which);
-            }
-        };
+        if (options.shouldShowNeutralButton()) {
+            builder.setNeutralButton(options.getNeutralText(context), new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    setRemindInterval(context);
+                    if (listener != null) listener.onClickButton(which);
+                }
+            });
+        }
 
-        DialogInterface.OnClickListener negativeClickListener = new DialogInterface.OnClickListener() {
+        builder.setNegativeButton(options.getNegativeText(context), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 setAgreeShowDialog(context, false);
                 if (listener != null) listener.onClickButton(which);
             }
-        };
-
-        if(options.getPositiveText() == null){
-            builder.setPositiveButton(options.getTextPositiveResId(), positiveClickListener);
-        }
-        else{
-            builder.setPositiveButton(options.getPositiveText(), positiveClickListener);
-        }
-
-        if (options.shouldShowNeutralButton()) {
-            if(options.getNeutralText() == null){
-                builder.setNeutralButton(options.getTextNeutralResId(), neutralClickListener);
-            }
-            else{
-                builder.setNeutralButton(options.getNeutralText(), neutralClickListener);
-            }
-        }
-
-        if(options.getNegativeText() == null){
-            builder.setNegativeButton(options.getTextNegativeResId(), negativeClickListener);
-        }
-        else{
-            builder.setNegativeButton(options.getNegativeText(), negativeClickListener);
-        }
+        });
 
         return builder.create();
     }

--- a/library/src/main/java/hotchemi/android/rate/DialogManager.java
+++ b/library/src/main/java/hotchemi/android/rate/DialogManager.java
@@ -18,9 +18,20 @@ final class DialogManager {
 
     static Dialog create(final Context context, DialogOptions options) {
         AlertDialog.Builder builder = getDialogBuilder(context);
-        builder.setMessage(options.getMessageResId());
+        if(options.getMessageText() == null) {
+            builder.setMessage(options.getMessageResId());
+        }
+        else{
+            builder.setMessage(options.getMessageText());
+        }
 
-        if (options.shouldShowTitle()) builder.setTitle(options.getTitleResId());
+        if (options.shouldShowTitle()){
+            if(options.getTitleText() == null) {
+                builder.setTitle(options.getTitleResId());
+            } else{
+                builder.setTitle(options.getTitleText());
+            }
+        }
 
         builder.setCancelable(options.getCancelable());
 
@@ -29,32 +40,53 @@ final class DialogManager {
 
         final OnClickButtonListener listener = options.getListener();
 
-        builder.setPositiveButton(options.getTextPositiveResId(), new DialogInterface.OnClickListener() {
+        DialogInterface.OnClickListener positiveClickListener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 context.startActivity(createIntentForGooglePlay(context));
                 setAgreeShowDialog(context, false);
                 if (listener != null) listener.onClickButton(which);
             }
-        });
+        };
 
-        if (options.shouldShowNeutralButton()) {
-            builder.setNeutralButton(options.getTextNeutralResId(), new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    setRemindInterval(context);
-                    if (listener != null) listener.onClickButton(which);
-                }
-            });
-        }
+        DialogInterface.OnClickListener neutralClickListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                setRemindInterval(context);
+                if (listener != null) listener.onClickButton(which);
+            }
+        };
 
-        builder.setNegativeButton(options.getTextNegativeResId(), new DialogInterface.OnClickListener() {
+        DialogInterface.OnClickListener negativeClickListener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 setAgreeShowDialog(context, false);
                 if (listener != null) listener.onClickButton(which);
             }
-        });
+        };
+
+        if(options.getPositiveText() == null){
+            builder.setPositiveButton(options.getTextPositiveResId(), positiveClickListener);
+        }
+        else{
+            builder.setPositiveButton(options.getPositiveText(), positiveClickListener);
+        }
+
+        if (options.shouldShowNeutralButton()) {
+            if(options.getNeutralText() == null){
+                builder.setNeutralButton(options.getTextNeutralResId(), neutralClickListener);
+            }
+            else{
+                builder.setNeutralButton(options.getNeutralText(), neutralClickListener);
+            }
+        }
+
+        if(options.getNegativeText() == null){
+            builder.setNegativeButton(options.getTextNegativeResId(), negativeClickListener);
+        }
+        else{
+            builder.setNegativeButton(options.getNegativeText(), negativeClickListener);
+        }
 
         return builder.create();
     }

--- a/library/src/main/java/hotchemi/android/rate/DialogOptions.java
+++ b/library/src/main/java/hotchemi/android/rate/DialogOptions.java
@@ -1,5 +1,6 @@
 package hotchemi.android.rate;
 
+import android.content.Context;
 import android.view.View;
 
 final class DialogOptions {
@@ -114,7 +115,10 @@ final class DialogOptions {
         this.listener = listener;
     }
 
-    public String getTitleText() {
+    public String getTitleText(Context context) {
+        if (titleText == null) {
+            return context.getString(titleResId);
+        }
         return titleText;
     }
 
@@ -122,7 +126,10 @@ final class DialogOptions {
         this.titleText = titleText;
     }
 
-    public String getMessageText() {
+    public String getMessageText(Context context) {
+        if (messageText == null) {
+            return context.getString(messageResId);
+        }
         return messageText;
     }
 
@@ -130,7 +137,10 @@ final class DialogOptions {
         this.messageText = messageText;
     }
 
-    public String getPositiveText() {
+    public String getPositiveText(Context context) {
+        if (positiveText == null) {
+            return context.getString(textPositiveResId);
+        }
         return positiveText;
     }
 
@@ -138,7 +148,10 @@ final class DialogOptions {
         this.positiveText = positiveText;
     }
 
-    public String getNeutralText() {
+    public String getNeutralText(Context context) {
+        if (neutralText == null) {
+            return context.getString(textNeutralResId);
+        }
         return neutralText;
     }
 
@@ -146,7 +159,10 @@ final class DialogOptions {
         this.neutralText = neutralText;
     }
 
-    public String getNegativeText() {
+    public String getNegativeText(Context context) {
+        if (negativeText == null) {
+            return context.getString(textNegativeResId);
+        }
         return negativeText;
     }
 

--- a/library/src/main/java/hotchemi/android/rate/DialogOptions.java
+++ b/library/src/main/java/hotchemi/android/rate/DialogOptions.java
@@ -20,6 +20,16 @@ final class DialogOptions {
 
     private int textNegativeResId = R.string.rate_dialog_no;
 
+    private String titleText = null;
+
+    private String messageText = null;
+
+    private String positiveText = null;
+
+    private String neutralText = null;
+
+    private String negativeText = null;
+
     private View view;
 
     private OnClickButtonListener listener;
@@ -104,4 +114,43 @@ final class DialogOptions {
         this.listener = listener;
     }
 
+    public String getTitleText() {
+        return titleText;
+    }
+
+    public void setTitleText(String titleText) {
+        this.titleText = titleText;
+    }
+
+    public String getMessageText() {
+        return messageText;
+    }
+
+    public void setMessageText(String messageText) {
+        this.messageText = messageText;
+    }
+
+    public String getPositiveText() {
+        return positiveText;
+    }
+
+    public void setPositiveText(String positiveText) {
+        this.positiveText = positiveText;
+    }
+
+    public String getNeutralText() {
+        return neutralText;
+    }
+
+    public void setNeutralText(String neutralText) {
+        this.neutralText = neutralText;
+    }
+
+    public String getNegativeText() {
+        return negativeText;
+    }
+
+    public void setNegativeText(String negativeText) {
+        this.negativeText = negativeText;
+    }
 }

--- a/sample/src/main/java/hotchemi/android/rate/sample/MainActivity.java
+++ b/sample/src/main/java/hotchemi/android/rate/sample/MainActivity.java
@@ -33,6 +33,18 @@ public class MainActivity extends Activity {
                 .setTextRateNow( R.string.new_rate_dialog_ok )
                 .monitor();
 
+        /*
+
+        Methods for setting text are overloaded, so if you need to set custom text at runtime
+        (for example if you retrieve your translations from server) set String
+        parameters instead of resource ids:
+
+        .setTitle("CustomTitle")
+        .setTextLater("Later")
+        and so on
+
+         */
+
         AppRate.showRateDialogIfMeetsConditions(this);
     }
 

--- a/sample/src/main/java/hotchemi/android/rate/sample/MainActivity.java
+++ b/sample/src/main/java/hotchemi/android/rate/sample/MainActivity.java
@@ -30,20 +30,8 @@ public class MainActivity extends Activity {
                 .setTitle(R.string.new_rate_dialog_title)
                 .setTextLater(R.string.new_rate_dialog_later)
                 .setTextNever(R.string.new_rate_dialog_never)
-                .setTextRateNow( R.string.new_rate_dialog_ok )
+                .setTextRateNow(R.string.new_rate_dialog_ok)
                 .monitor();
-
-        /*
-
-        Methods for setting text are overloaded, so if you need to set custom text at runtime
-        (for example if you retrieve your translations from server) set String
-        parameters instead of resource ids:
-
-        .setTitle("CustomTitle")
-        .setTextLater("Later")
-        and so on
-
-         */
 
         AppRate.showRateDialogIfMeetsConditions(this);
     }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
 
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/hello_world" />
+        android:text="@string/hello_world"/>
 </LinearLayout>

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -3,4 +3,4 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
 
-    </resources>
+</resources>


### PR DESCRIPTION
I have added support for custom String content (title, message, button texts) at runtime. I designed it in such way that the API is backward compatible. If you are setting content with a String object it has priority over resources id. So, if String attribute is not null, String attribute is used... 

This could be implemented also another way, minimizing number of methods and providing cleaner code. DialogOptions constructor should receive Context object, which would enable us to use only methods that return String objects (without resource identifiers), method for setting message text would look something like this:
public String getMessageText() {
       if(meesageText != null)
             return messageText; 
       else 
             return mContext.getString(R.string.rate_dialog_message);
}
 