### PR TITLE
Add method to destroy the singleton and release the Context

### DIFF
--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -53,6 +53,10 @@ public class AppRate {
         return singleton;
     }
 
+    public static void destroy() {
+        singleton = null;
+    }
+
     public static boolean showRateDialogIfMeetsConditions(Activity activity) {
         boolean isMeetsConditions = singleton.isDebug || singleton.shouldShowRateDialog();
         if (isMeetsConditions) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,4 +24,8 @@ repositories {
 
 dependencies {
     compile project(':library')
+    // Leak detection
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
+    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
+    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -5,10 +5,12 @@
 
     <application
         android:allowBackup="false"
+        android:name=".ExampleApplication"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
         <activity
             android:name=".MainActivity"
+            android:theme="@style/Theme.AppCompat"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/sample/src/main/java/hotchemi/android/rate/sample/ExampleApplication.java
+++ b/sample/src/main/java/hotchemi/android/rate/sample/ExampleApplication.java
@@ -1,0 +1,13 @@
+package hotchemi.android.rate.sample;
+
+import android.app.Application;
+
+import com.squareup.leakcanary.LeakCanary;
+
+public class ExampleApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        LeakCanary.install(this);
+    }
+}

--- a/sample/src/main/java/hotchemi/android/rate/sample/MainActivity.java
+++ b/sample/src/main/java/hotchemi/android/rate/sample/MainActivity.java
@@ -37,4 +37,9 @@ public class MainActivity extends Activity {
         AppRate.showRateDialogIfMeetsConditions(this);
     }
 
+    @Override
+    protected void onDestroy() {
+        AppRate.destroy();
+        super.onDestroy();
+    }
 }


### PR DESCRIPTION
Calling `AppRate.destroy()` ensures that the context has no references and can be freed if needed.

Also add LeakCanary on the sample application to ensure that the memory leak was fixed.