### PR TITLE
Optional custom event requirements for showing dialog

### DIFF
--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -227,7 +227,7 @@ public final class AppRate {
     }
 
     private boolean isOverCustomEventRequirements() {
-        for(Map.Entry<String, Long> eventRequirement: customEventCounts.entrySet()) {
+        for(Map.Entry<String, Long> eventRequirement : customEventCounts.entrySet()) {
             Long currentCount = getCustomEventCount(context, eventRequirement.getKey());
             if(currentCount < eventRequirement.getValue()) {
                 return false;

--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -16,6 +16,7 @@ import static hotchemi.android.rate.PreferenceHelper.getRemindInterval;
 import static hotchemi.android.rate.PreferenceHelper.isFirstLaunch;
 import static hotchemi.android.rate.PreferenceHelper.setInstallDate;
 import static hotchemi.android.rate.PreferenceHelper.getCustomEventCount;
+import static hotchemi.android.rate.PreferenceHelper.setCustomEventCount;
 
 public final class AppRate {
 
@@ -77,8 +78,8 @@ public final class AppRate {
         return this;
     }
 
-    public AppRate setMinimumEventCount(String eventName, long count) {
-        this.customEventCounts.put(eventName, count);
+    public AppRate setMinimumEventCount(String eventName, long minimumCount) {
+        this.customEventCounts.put(eventName, minimumCount);
         return this;
     }
 
@@ -184,11 +185,11 @@ public final class AppRate {
     }
 
     public AppRate incrementEventCount(String eventName) {
-        return setEventCount(eventName, getCustomEventCount(context,eventName) + 1);
+        return setEventCountValue(eventName, getCustomEventCount(context,eventName) + 1);
     }
 
-    public AppRate setEventCount(String eventName, long count) {
-        PreferenceHelper.setCustomEventCount(context, eventName, count);
+    public AppRate setEventCountValue(String eventName, long countValue) {
+        setCustomEventCount(context, eventName, countValue);
         return this;
     }
 

--- a/library/src/main/java/hotchemi/android/rate/PreferenceHelper.java
+++ b/library/src/main/java/hotchemi/android/rate/PreferenceHelper.java
@@ -18,6 +18,8 @@ final class PreferenceHelper {
 
     private static final String PREF_KEY_REMIND_INTERVAL = "android_rate_remind_interval";
 
+    private static final String PREF_CUSTOM_EVENT_KEY_PREFIX = "android_rate_custom_event_prefix_";
+
     private PreferenceHelper() {
     }
 
@@ -91,6 +93,22 @@ final class PreferenceHelper {
 
     static boolean isFirstLaunch(Context context) {
         return getPreferences(context).getLong(PREF_KEY_INSTALL_DATE, 0) == 0L;
+    }
+
+    /**
+     * Add a prefix for the key for each custom event,
+     * so that there is no clash with existing keys (PREF_KEY_LAUNCH_TIME, PREF_KEY_INSTALL_DATE, etc.)
+     */
+    static long getCustomEventCount(Context context, String eventName) {
+        String eventKey = PREF_CUSTOM_EVENT_KEY_PREFIX + eventName;
+        return getPreferences(context).getLong(eventKey, 0);
+    }
+
+    static void setCustomEventCount(Context context, String eventName, long eventCount) {
+        String eventKey = PREF_CUSTOM_EVENT_KEY_PREFIX + eventName;
+        SharedPreferences.Editor editor = getPreferencesEditor(context);
+        editor.putLong(eventKey, eventCount);
+        editor.apply();
     }
 
 }


### PR DESCRIPTION
#106

Users can add additional optional requirements for showing dialog. Each requirement can be added/referenced as a unique string. Users can set a minimum count for each such event (for eg. "action_performed" 3 times, "button_clicked" 5 times, etc.)
