### PR TITLE
Allow the use of Fully Custom Dialog (from support library)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-23.0.2
-    - android-23
+    - build-tools-25.0.2
+    - android-25
     - extra-google-google_play_services
     - extra-android-m2repository
     - extra-android-support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-- 2015/12/05 1.0.1
+- 2016/12/05 1.0.1
     - Fix https://github.com/hotchemi/Android-Rate/pull/101.
     - Fix https://github.com/hotchemi/Android-Rate/pull/103.
 - 2016/03/20 1.0.0

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 23
+        targetSdkVersion 25
     }
 }
 

--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -6,13 +6,7 @@ import android.view.View;
 
 import java.util.Date;
 
-import static hotchemi.android.rate.DialogManager.create;
-import static hotchemi.android.rate.PreferenceHelper.getInstallDate;
-import static hotchemi.android.rate.PreferenceHelper.getIsAgreeShowDialog;
-import static hotchemi.android.rate.PreferenceHelper.getLaunchTimes;
-import static hotchemi.android.rate.PreferenceHelper.getRemindInterval;
-import static hotchemi.android.rate.PreferenceHelper.isFirstLaunch;
-import static hotchemi.android.rate.PreferenceHelper.setInstallDate;
+import static hotchemi.android.rate.PreferenceHelper.*;
 
 public final class AppRate {
 
@@ -29,6 +23,8 @@ public final class AppRate {
     private int remindInterval = 1;
 
     private boolean isDebug = false;
+
+    private DialogManager.Factory dialogManagerFactory = new DefaultDialogManager.Factory();
 
     private AppRate(Context context) {
         this.context = context.getApplicationContext();
@@ -173,6 +169,11 @@ public final class AppRate {
         return this;
     }
 
+    public AppRate setDialogManagerFactory(DialogManager.Factory dialogManagerFactory) {
+        this.dialogManagerFactory = dialogManagerFactory;
+        return this;
+    }
+
     public void monitor() {
         if (isFirstLaunch(context)) {
             setInstallDate(context);
@@ -182,7 +183,7 @@ public final class AppRate {
 
     public void showRateDialog(Activity activity) {
         if (!activity.isFinishing()) {
-            create(activity, options).show();
+            dialogManagerFactory.createDialogManager(activity, options).createDialog().show();
         }
     }
 

--- a/library/src/main/java/hotchemi/android/rate/DefaultDialogManager.java
+++ b/library/src/main/java/hotchemi/android/rate/DefaultDialogManager.java
@@ -1,0 +1,84 @@
+package hotchemi.android.rate;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.view.View;
+
+import static hotchemi.android.rate.IntentHelper.createIntentForAmazonAppstore;
+import static hotchemi.android.rate.IntentHelper.createIntentForGooglePlay;
+import static hotchemi.android.rate.PreferenceHelper.setAgreeShowDialog;
+import static hotchemi.android.rate.PreferenceHelper.setRemindInterval;
+import static hotchemi.android.rate.Utils.getDialogBuilder;
+
+public class DefaultDialogManager implements DialogManager {
+
+    static class Factory implements DialogManager.Factory {
+        @Override
+        public DialogManager createDialogManager(Context context, DialogOptions options) {
+            return new DefaultDialogManager(context, options);
+        }
+    }
+
+    private final Context context;
+    private final DialogOptions options;
+    private final OnClickButtonListener listener;
+
+    protected final DialogInterface.OnClickListener positiveListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            final Intent intentToAppstore = options.getStoreType() == StoreType.GOOGLEPLAY ?
+                    createIntentForGooglePlay(context) : createIntentForAmazonAppstore(context);
+            context.startActivity(intentToAppstore);
+            setAgreeShowDialog(context, false);
+            if (listener != null) listener.onClickButton(which);
+        }
+    };
+    protected final DialogInterface.OnClickListener negativeListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            setAgreeShowDialog(context, false);
+            if (DefaultDialogManager.this.listener != null) DefaultDialogManager.this.listener.onClickButton(which);
+        }
+    };
+    protected final DialogInterface.OnClickListener neutralListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            setRemindInterval(context);
+            if (listener != null) listener.onClickButton(which);
+        }
+    };
+
+    public DefaultDialogManager(final Context context, final DialogOptions options) {
+        this.context = context;
+        this.options = options;
+        this.listener = options.getListener();
+    }
+
+    public Dialog createDialog() {
+        AlertDialog.Builder builder = getDialogBuilder(context);
+        builder.setMessage(options.getMessageText(context));
+
+        if (options.shouldShowTitle()) builder.setTitle(options.getTitleText(context));
+
+        builder.setCancelable(options.getCancelable());
+
+        View view = options.getView();
+        if (view != null) builder.setView(view);
+
+        builder.setPositiveButton(options.getPositiveText(context), positiveListener);
+
+        if (options.shouldShowNeutralButton()) {
+            builder.setNeutralButton(options.getNeutralText(context), neutralListener);
+        }
+
+        if (options.shouldShowNegativeButton()) {
+            builder.setNegativeButton(options.getNegativeText(context), negativeListener);
+        }
+
+        return builder.create();
+    }
+
+}

--- a/library/src/main/java/hotchemi/android/rate/DialogManager.java
+++ b/library/src/main/java/hotchemi/android/rate/DialogManager.java
@@ -1,68 +1,14 @@
 package hotchemi.android.rate;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.view.View;
 
-import static hotchemi.android.rate.IntentHelper.createIntentForAmazonAppstore;
-import static hotchemi.android.rate.IntentHelper.createIntentForGooglePlay;
-import static hotchemi.android.rate.PreferenceHelper.setAgreeShowDialog;
-import static hotchemi.android.rate.PreferenceHelper.setRemindInterval;
-import static hotchemi.android.rate.Utils.getDialogBuilder;
+public interface DialogManager {
 
-final class DialogManager {
-
-    private DialogManager() {
+    interface Factory {
+        DialogManager createDialogManager(final Context context, final DialogOptions options);
     }
 
-    static Dialog create(final Context context, final DialogOptions options) {
-        AlertDialog.Builder builder = getDialogBuilder(context);
-        builder.setMessage(options.getMessageText(context));
-
-        if (options.shouldShowTitle()) builder.setTitle(options.getTitleText(context));
-
-        builder.setCancelable(options.getCancelable());
-
-        View view = options.getView();
-        if (view != null) builder.setView(view);
-
-        final OnClickButtonListener listener = options.getListener();
-
-        builder.setPositiveButton(options.getPositiveText(context), new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                final Intent intentToAppstore = options.getStoreType() == StoreType.GOOGLEPLAY ?
-                createIntentForGooglePlay(context) : createIntentForAmazonAppstore(context);
-                context.startActivity(intentToAppstore);
-                setAgreeShowDialog(context, false);
-                if (listener != null) listener.onClickButton(which);
-            }
-        });
-
-        if (options.shouldShowNeutralButton()) {
-            builder.setNeutralButton(options.getNeutralText(context), new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    setRemindInterval(context);
-                    if (listener != null) listener.onClickButton(which);
-                }
-            });
-        }
-
-        if (options.shouldShowNegativeButton()) {
-            builder.setNegativeButton(options.getNegativeText(context), new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    setAgreeShowDialog(context, false);
-                    if (listener != null) listener.onClickButton(which);
-                }
-            });
-        }
-
-        return builder.create();
-    }
+    Dialog createDialog();
 
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Added a DialogManager.Factory interface to use any AlertDialog.Builder implementation.
Like https://developer.android.com/reference/android/support/v7/app/AlertDialog.html

Please merge and release unless you want to use the support AlertDialog as a default ;-)