### PR TITLE
Change Hebrew translation from female to both sex, male and female.

### DIFF
--- a/library/src/main/res/values-iw/strings.xml
+++ b/library/src/main/res/values-iw/strings.xml
@@ -1,7 +1,7 @@
 <resources>
-    <string name="rate_dialog_title">דרגי את האפלקציה</string>
-    <string name="rate_dialog_message">אם את נהנית מהשימוש באפליקציה, מה דעתך לדרג אותה? זה לא ייקח יותר מדקה. תודה על התמיכה!</string>
-    <string name="rate_dialog_ok">דרגי כעת</string>
+    <string name="rate_dialog_title">דרגו את האפלקציה</string>
+    <string name="rate_dialog_message">אם אתם נהנים מהשימוש באפליקציה, מה דעתכם לדרג אותה? זה לא ייקח יותר מדקה. תודה על התמיכה!</string>
+    <string name="rate_dialog_ok">דרגו כעת</string>
     <string name="rate_dialog_cancel">אחר כך</string>
     <string name="rate_dialog_no">לא תודה</string>
 </resources>


### PR DESCRIPTION
The heberw translation refered just to female sex.
Now it refers both male and female.