### PR TITLE
Convert int into long to compare long with long

### DIFF
--- a/library/src/main/java/hotchemi/android/rate/AppRate.java
+++ b/library/src/main/java/hotchemi/android/rate/AppRate.java
@@ -54,7 +54,7 @@ public final class AppRate {
     }
 
     private static boolean isOverDate(long targetDate, int threshold) {
-        return new Date().getTime() - targetDate >= threshold * 24 * 60 * 60 * 1000;
+        return new Date().getTime() - targetDate >= ((long)threshold) * 24 * 60 * 60 * 1000;
     }
 
     public AppRate setLaunchTimes(int launchTimes) {


### PR DESCRIPTION
We noticed a problem when setting the reminder to 30 days (setRemindInterval() takes an int arg but is compared with a long in isOverDate())
This commit should fix the problem.
